### PR TITLE
Add FrameThrower — cinematography reference node

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ _The ComfyUI Mascot_
 - [Comfyroll Custom Nodes](https://github.com/RockOfFire/ComfyUI_Comfyroll_CustomNodes)
 - [smzNodes](https://github.com/shiimizu/ComfyUI_smZNodes)
 - [Prompt Expansion](https://civitai.com/models/146480/prompt-expansion-custom-node-for-comfyui)
+- [FrameThrower](https://github.com/framethrower-ai/comfyui-framethrower): search a cinematography reference library of film stills by lighting, lens character, shot size, colour and mood, and load the result as an IMAGE node
 
 
 ## Workflows


### PR DESCRIPTION
Adds FrameThrower to **Custom Nodes and Plugins**.

A node that searches a cinematography reference library — film stills indexed frame by frame on lighting, lens character, shot size, camera angle, colour and mood — and returns the result directly as an `IMAGE`, so it drops straight into an img2img, ControlNet or IPAdapter chain without leaving the graph.

The point is style reference from real cinematography rather than a text prompt describing it.

- Node: https://github.com/framethrower-ai/comfyui-framethrower
- Free tier, no card required.

One line added at the end of the section, matching the existing `- [Name](url): description` format.