### PR TITLE
Add OpenLayer (Photoshop plugin for ComfyUI)

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ _The ComfyUI Mascot_
 - [MentalDiffusion](https://github.com/nimadez/mental-diffusion): Stable diffusion web interface for ComfyUI
 - [CushyStudio](https://github.com/rvion/CushyStudio): Next-Gen Generative Art Studio (+ typescript SDK) - based on ComfyUI
 - [Krita Plugin](https://github.com/Acly/krita-ai-diffusion)
+- [OpenLayer](https://github.com/MehranMarxian/OpenLayer): Photoshop plugin for a local ComfyUI server - generate, inpaint, upscale, and split a flat image back into separate layers, imported as editable Photoshop layers
 
 ## License
 


### PR DESCRIPTION
Adds one entry under **Projects using ComfyUI**, next to the Krita plugin it parallels.

[OpenLayer](https://github.com/MehranMarxian/OpenLayer) is a free, MIT-licensed Adobe Photoshop UXP panel that drives a ComfyUI server running on the user's own machine. Text to image, image to image, sketch to image, inpaint, outpaint, upscale, and a layer-decomposition tool; results are imported into the open Photoshop document as real, editable layers rather than flattened images. Nothing is sent off the machine.

It is alpha software and says so plainly in its own README — happy to hold off if you would rather only list stable projects.

Thanks for maintaining the list.